### PR TITLE
Fix date of first meeting

### DIFF
--- a/meetings/2022-09-02_ElixirConfLunch.md
+++ b/meetings/2022-09-02_ElixirConfLunch.md
@@ -8,6 +8,7 @@ Attendees:
 - Jason Axelson
 
 Location: ElixirConf 2022 Lunch
+Date: 2022-09-02
 
 Governance
 - Are we aligned with Scenic's general direction?


### PR DESCRIPTION
I realized that the date was incorrect. This PR fixes it and adds a date field in the meeting note